### PR TITLE
Include Media library images in resizing logic

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Kentico.Xperience.webapp" Version="29.1.4" />
-	<PackageVersion Include="SkiaSharp" Version="2.88.8" />
+	  <PackageVersion Include="SkiaSharp" Version="2.88.8" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.8" />
   </ItemGroup>
 </Project>

--- a/src/Middleware/ImageProcessingMiddleware.cs
+++ b/src/Middleware/ImageProcessingMiddleware.cs
@@ -121,7 +121,7 @@ public class ImageProcessingMiddleware(RequestDelegate next, IEventLogService ev
             return imageBytes;
         }
 
-        if (width <= 0 && height <= 0 && maxSideSize <= 0)
+        if (width <= 0 && height <= 0 && maxSideSize <= 0 && format == contentType)
         {
             return imageBytes;
         }
@@ -138,8 +138,7 @@ public class ImageProcessingMiddleware(RequestDelegate next, IEventLogService ev
 
             var resizedBitmap = originalBitmap;
 
-            // Resize the image if it is a Content item asset only as Media library images are already resized by XbyK
-            if (IsPathContentItemAsset(path))
+            if (width > 0 || height > 0 || maxSideSize > 0)
             {
                 var newDims = ImageHelper.EnsureImageDimensions(width, height, maxSideSize, originalBitmap.Width, originalBitmap.Height);
                 resizedBitmap = originalBitmap.Resize(new SKImageInfo(newDims[0], newDims[1]), SKFilterQuality.High);


### PR DESCRIPTION
Since `Kentico.Xperience.MiniProfiler` includes a reference to `Kentico.Xperience.ImageProcessing`, I initially thought that resizing was included out-of-the-box during the testing for the previous pull request (https://github.com/liamgold/xperience-community-image-processing/pull/3). It turns out it is not. Therefore, this pull request adds direct support for Media Library image resizing. Please, test on your end.