### PR TITLE
docs: add recommendation for Kentico's native Image Variants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a **Xperience by Kentico** middleware library that provides image processing capabilities for the Xperience by Kentico platform. It's packaged as a NuGet package for distribution.
 
+**Note:** Kentico now offers native Image Variants (https://docs.kentico.com/documentation/business-users/content-hub/content-item-assets#image-variants) for Content Hub assets. This package remains useful for Media library support, on-the-fly processing, and dynamic transformations. Future deprecation is planned as Kentico's native solution matures.
+
 **Key Technology Stack:**
 - Backend: .NET 8.0, ASP.NET Core, Xperience by Kentico 30.11.1+
 - Image Processing: SkiaSharp 3.119.1

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@
 
 This package provides a way to resize images and convert them to `webp`, `jpg`, and `png` formats. It supports images from *Media libraries* and Content hub items stored as *Content item assets*.
 
+## ⚠️ Consider Kentico's Native Image Variants
+
+**Before using this package**, consider [Kentico's native Image Variants feature](https://docs.kentico.com/documentation/business-users/content-hub/content-item-assets#image-variants) introduced in recent versions. The native solution:
+- ✅ Officially supported by Kentico
+- ✅ Integrated into the Content Hub UI
+- ✅ Pre-generated variants for better performance
+- ✅ No additional dependencies
+
+**This package is still useful if you need:**
+- On-the-fly image processing without pre-generation
+- Media library image support (native variants are Content Hub only)
+- Dynamic query parameter-based transformations
+- Fit modes (`cover`, `contain`, `fill`) and crop positioning
+- Legacy project compatibility
+
+**Future deprecation:** As Kentico's native solution matures and adds more features, this package may be deprecated. For new projects, we recommend starting with the native Image Variants feature.
+
 ## Library Version Matrix
 
 | Xperience Version | Library Version |


### PR DESCRIPTION
## Summary

Adds a prominent notice in the README recommending users consider [Kentico's native Image Variants feature](https://docs.kentico.com/documentation/business-users/content-hub/content-item-assets#image-variants) before using this package.

## Changes

### README.md
Added new section **"⚠️ Consider Kentico's Native Image Variants"** that:
- ✅ Links to Kentico's official documentation
- ✅ Explains benefits of the native solution (officially supported, pre-generated, integrated UI)
- ✅ Clarifies when this package is still useful:
  - Media library support (native variants are Content Hub only)
  - On-the-fly processing without pre-generation
  - Dynamic query parameter-based transformations
  - Fit modes and crop positioning
  - Legacy project compatibility
- ✅ Sets expectation for future deprecation

### CLAUDE.md
Added brief note about Kentico's native Image Variants for context.

## Rationale

As suggested in #8, Kentico now provides native Image Variants functionality that covers many of this package's use cases. It's important to:
1. Guide new users to the officially supported solution
2. Be transparent about this package's future
3. Still support existing users who need features not in the native solution

## Tone

The notice is **balanced and helpful**:
- Not overly negative or discouraging
- Clearly explains when each solution is appropriate
- Supports users who legitimately need this package
- Honest about future deprecation plans

Closes #8

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)